### PR TITLE
Opt connection pool

### DIFF
--- a/include/hash.h
+++ b/include/hash.h
@@ -50,14 +50,14 @@ typedef my_bool (*my_hash_walk_action)(void *,void *);
 
 typedef struct st_hash {
   size_t key_offset,key_length;		/* Length of key if const length */
-  size_t blength;
-  ulong records;
-  uint flags;
-  DYNAMIC_ARRAY array;				/* Place for hash_keys */
-  my_hash_get_key get_key;
-  my_hash_function hash_function;
-  void (*free)(void *);
-  CHARSET_INFO *charset;
+  size_t blength;                 /* Buffmax length, 2^n */
+  ulong records;                  /* Number of elements */
+  uint flags;                     /* 0 | HASH_UNIQUE | HASH_THREAD_SPECIFIC */
+  DYNAMIC_ARRAY array;				    /* Place for all hash_keys in this single array */
+  my_hash_get_key get_key;        /* get_key function, if null, use key_offset and key_length */
+  my_hash_function hash_function; /* hash_function, default use my_hash_sort() */
+  void (*free)(void *);           /* if no need, leave it as NULL */
+  CHARSET_INFO *charset;          /* character set */
 } HASH;
 
 /* A search iterator state */

--- a/include/my_list.h
+++ b/include/my_list.h
@@ -38,6 +38,7 @@ extern int list_walk(LIST *,list_walk_action action,unsigned char * argument);
 #define list_rest(a) ((a)->next)
 #define list_push(a,b) (a)=list_cons((b),(a))
 #define list_pop(A) {LIST *old=(A); (A)=list_delete(old,old); my_free(old); }
+#define list_top(A) ((A) ? ((A)->data) : NULL)
 
 #ifdef	__cplusplus
 }

--- a/mysys/array.c
+++ b/mysys/array.c
@@ -32,7 +32,7 @@
 
   DESCRIPTION
     init_dynamic_array() initiates array and allocate space for
-    init_alloc eilements.
+    init_alloc elements.
     Array is usable even if space allocation failed, hence, the
     function never returns TRUE.
 

--- a/mysys/lf_hash.c
+++ b/mysys/lf_hash.c
@@ -361,6 +361,11 @@ void lf_hash_init(LF_HASH *hash, uint element_size, uint flags,
   DBUG_ASSERT(get_key ? !key_offset && !key_length : key_length);
 }
 
+
+/*
+  DESCRIPTION
+    deinit the HASH
+*/
 void lf_hash_destroy(LF_HASH *hash)
 {
   LF_SLIST *el, **head= (LF_SLIST **)lf_dynarray_value(&hash->array, 0);

--- a/storage/spider/mysql-test/spider/r/spider_sys_variables.result
+++ b/storage/spider/mysql-test/spider/r/spider_sys_variables.result
@@ -104,7 +104,7 @@ spider_transaction_one_shard	OFF
 spider_update_with_primary_key_first	ON
 spider_use_all_conns_snapshot	OFF
 spider_use_consistent_snapshot	OFF
-spider_version	3.6.1
+spider_version	3.7.1
 spider_with_begin_commit	OFF
 spider_xa_register_mode	1
 

--- a/storage/spider/spd_conn.cc
+++ b/storage/spider/spd_conn.cc
@@ -89,8 +89,7 @@ extern pthread_mutex_t spider_tbl_mutex;
 extern SPIDER_TRX *spider_global_trx;
 
 extern HASH spider_open_tables;
-HASH spider_open_connections;
-uint spider_open_connections_id;
+SPIDER_CONN_POOL spd_connect_pools;
 HASH spider_ipport_conns;
 HASH spider_for_sts_conns;
 HASH spider_for_sts_share;
@@ -99,7 +98,7 @@ long spider_conn_mutex_id = 0;
 const char *spider_open_connections_func_name;
 const char *spider_open_connections_file_name;
 ulong spider_open_connections_line_no;
-pthread_mutex_t spider_conn_mutex;
+// pthread_mutex_t spider_conn_mutex;
 pthread_mutex_t spider_conn_meta_mutex;
 HASH spider_conn_meta_info;
 
@@ -111,10 +110,181 @@ extern PSI_thread_key spd_key_thd_get_status;
 volatile bool get_status_init = FALSE;
 pthread_t get_status_thread;
 
+/**
+  conn_queue is a queue (actually stack) to store SPIDER_CONN
+  in order to reduce memcpy the whole SPIDER_CONN, we insert
+  SPIDER_CONN ** into the queue
+  @todo: change it from stack to queue, which can increase
+         the performance of recycling.
+*/
+typedef struct{
+  pthread_mutex_t mtx;   // mutex of the queue
+  bool mtx_inited;       // whether the mutex has inited
+  DYNAMIC_ARRAY *q_ptr;  // pointer of the queue (actually stack)
+  char *hash_key;        // hash key of conn_queue
+  uint key_len;          // length of the key
+}conn_queue;
+
 typedef struct {
-  HASH *hash_info;
+  SPIDER_CONN_POOL *hash_info;
   DYNAMIC_STRING_ARRAY *arr_info[2];
 } delegate_param;
+
+/* HASH free function */
+static void conn_pool_hash_free(void *entry) {
+  conn_queue *cq = (conn_queue *)entry;
+  assert(cq->q_ptr);
+  clear_dynamic_array(cq->q_ptr); /* ignore failure */
+  my_free(cq->q_ptr);
+  cq->q_ptr = NULL;
+  my_free(cq);
+}
+
+/** 
+  Init spider open connections
+  1. init rwlock, 2. init hash
+  @param    get_key     get_key function, how to find key from the struct
+  @param    init_cap    init capacity of the hash (init alloc)
+  @param    charset     character set info
+  @return   false if OK | TRUE if OOM
+*/
+bool SPIDER_CONN_POOL::init(my_hash_get_key get_key, uint init_cap,
+                            CHARSET_INFO *charset) {
+  mysql_rwlock_init(0, &rw_lock);
+  if (my_hash_init(&connections, charset, init_cap, 0, 0,
+                   (my_hash_get_key)get_key, 
+                   (void (*)(void*))conn_pool_hash_free, HASH_UNIQUE))
+    return true; /* out of memory */
+  conn_inited = true;
+  return false; /* OK */
+}
+
+/**
+  Destroy spider open connections
+  1. destroy hash 2. destroy rwlock
+*/
+void SPIDER_CONN_POOL::destroy() {
+  if (conn_inited) {
+    mysql_rwlock_destroy(&rw_lock);
+    my_hash_free(&connections);
+    conn_inited = false;
+  }
+}
+
+/**
+  Put the connection back to connection pool
+  @param    conn    spider connection
+  @return   FALSE if OK | TRUE if OOM
+*/
+bool SPIDER_CONN_POOL::put_conn(SPIDER_CONN *conn) {
+  void *record = NULL;
+  conn_queue *cq;
+  my_bool ret;
+  my_hash_value_type v = conn->conn_key_hash_value;
+  
+  mysql_rwlock_rdlock(&rw_lock);
+  while (!(record = my_hash_search_using_hash_value(&connections, v,
+          (uchar *)conn->conn_key, conn->conn_key_length))) {
+    mysql_rwlock_unlock(&rw_lock);
+    // if not exists, we need to create and insert a queue into the hash
+    cq = (conn_queue *)my_malloc(sizeof(conn_queue), MY_ZEROFILL | MY_WME);
+    if (!cq) return true; /* OOM */
+    mysql_mutex_init(0, &cq->mtx, MY_MUTEX_INIT_FAST);
+    cq->mtx_inited = true;
+    cq->q_ptr = (DYNAMIC_ARRAY *)my_malloc(sizeof(DYNAMIC_ARRAY), MY_WME);
+    if (!cq->q_ptr) { my_free(cq); cq->mtx_inited = false; return true; /* OOM */ }
+    if (my_init_dynamic_array(cq->q_ptr, sizeof(SPIDER_CONN **), 64, 64, MYF(0))) {
+      my_free(cq); cq->mtx_inited = false; return true;
+    }
+    cq->hash_key = conn->conn_key;
+    cq->key_len = conn->conn_key_length;
+    mysql_rwlock_wrlock(&rw_lock);
+    if (my_hash_insert(&connections, (uchar *)cq)) {
+      /* insert failed means some other thread has inserted it for us*/
+      my_free(cq->q_ptr);
+      my_free(cq);
+    } else {
+      record = (void *)cq;
+      break;
+    }
+  }
+  mysql_rwlock_unlock(&rw_lock);
+  /* code reaches here means we got the queue */
+  cq = (conn_queue *)(record);
+  pthread_mutex_lock(&cq->mtx);
+  ret = insert_dynamic(cq->q_ptr, (void *)(&conn)); /* SPIDER_CONN ** */
+  pthread_mutex_unlock(&cq->mtx);
+  return !!ret; // return TRUE means OOM
+}
+
+/**
+  Search and delete spider conn from the pool using hash value
+  @param    v       hash value
+  @param    key     hash key
+  @param    key_len length of the key
+  @return   NULL if search/delete failed | SPD_CONN *
+*/
+SPIDER_CONN *SPIDER_CONN_POOL::get_conn(my_hash_value_type v,
+                                        uchar *key, uint key_len) {
+  SPIDER_CONN *spd_conn = NULL;
+  SPIDER_CONN **conn_ptr = NULL;
+  conn_queue *cq = NULL;
+
+  mysql_rwlock_rdlock(&rw_lock);
+  if (!(cq = (conn_queue *)my_hash_search_using_hash_value(
+        &connections, v, key, key_len))) {
+    mysql_rwlock_unlock(&rw_lock);
+    return NULL; /* no queue of this hash value exist */
+  }
+  mysql_rwlock_unlock(&rw_lock);
+
+  pthread_mutex_lock(&cq->mtx);
+  conn_ptr = (SPIDER_CONN **)pop_dynamic(cq->q_ptr);
+  if (conn_ptr) spd_conn = *conn_ptr;
+  pthread_mutex_unlock(&cq->mtx);
+  return spd_conn; /* NULL means the queue by this hash value is empty */
+}
+
+/**
+  Search and delete spider conn from the pool using hash key
+  @param    key     hash key
+  @param    key_len length of the key
+  @return NULL if search/delete failed | SPD_CONN *
+*/
+SPIDER_CONN *SPIDER_CONN_POOL::get_conn_by_key(uchar *key, uint key_len) {
+  SPIDER_CONN *spd_conn = NULL;
+  SPIDER_CONN **conn_ptr = NULL;
+  conn_queue *cq = NULL;
+
+  mysql_rwlock_rdlock(&rw_lock);
+  if (!(cq = (conn_queue *)my_hash_search(&connections, key, key_len))) {
+    mysql_rwlock_unlock(&rw_lock);
+    return NULL; /* no queue of this hash key exist */
+  }
+  mysql_rwlock_unlock(&rw_lock);
+
+  pthread_mutex_lock(&cq->mtx);
+  conn_ptr = (SPIDER_CONN **)pop_dynamic(cq->q_ptr);
+  if (conn_ptr) spd_conn = *conn_ptr;
+  pthread_mutex_unlock(&cq->mtx);
+  return spd_conn; /* NULL means the queue by this hash key is empty */
+}
+
+/* iterate through all elements and execute my_polling_last_visited */
+void SPIDER_CONN_POOL::iterate(my_hash_delegate_func iter_func, void *param) {
+  my_hash_delegate(&connections, iter_func, param);
+}
+
+/**
+   calculate hash from key
+   it utilize the charset of spd_connect_pool to calculate hash value
+   @note this function is not only used in spd_connect_pool, but also
+   other scenarios where hash value of conn_keys must be calculated
+*/
+my_hash_value_type SPIDER_CONN_POOL::calc_hash(const uchar *key, 
+                                               size_t length) {
+  return my_hash_sort(connections.charset, key, length);
+}
 
 /* for spider_open_connections and trx_conn_hash */
 uchar *spider_conn_get_key(SPIDER_CONN *conn, size_t *length,
@@ -126,6 +296,18 @@ uchar *spider_conn_get_key(SPIDER_CONN *conn, size_t *length,
   spider_print_keys(conn->conn_key, conn->conn_key_length);
 #endif
   DBUG_RETURN((uchar *)conn->conn_key);
+}
+
+/* for spider connection pool get key */
+uchar *spider_conn_pool_get_key(void *record, size_t *length,
+                                my_bool not_used __attribute__((unused))) {
+  DBUG_ENTER("spider_conn_pool_get_key");
+  conn_queue *cq = (conn_queue *)record;
+  *length = cq->key_len;
+#ifndef DBUG_OFF
+  spider_print_keys(cq->hash_key, cq->key_len);
+#endif
+  DBUG_RETURN((uchar *)(cq->hash_key));
 }
 
 uchar *spider_ipport_conn_get_key(SPIDER_IP_PORT_CONN *ip_port, size_t *length,
@@ -274,10 +456,10 @@ void spider_free_conn_from_trx(SPIDER_TRX *trx, SPIDER_CONN *conn, bool another,
           spider_db_free_result((ha_spider *)conn->quick_target, FALSE)) {
         spider_free_conn(conn);
       } else {
-        pthread_mutex_lock(&spider_conn_mutex);
-        uint old_elements = spider_open_connections.array.max_element;
-        if (my_hash_insert(&spider_open_connections, (uchar *)conn)) {
-          pthread_mutex_unlock(&spider_conn_mutex);
+        // pthread_mutex_lock(&spider_conn_mutex);
+        // to avoid memcpy, we insert SPIDER_CONN ** to spd_connect_pools
+        if (spd_connect_pools.put_conn(conn)) {
+          // pthread_mutex_unlock(&spider_conn_mutex);
           spider_free_conn(conn);
         } else {
           if (ip_port_conn) { /* exists */
@@ -286,12 +468,6 @@ void spider_free_conn_from_trx(SPIDER_TRX *trx, SPIDER_CONN *conn, bool another,
               pthread_cond_signal(&ip_port_conn->cond);
               pthread_mutex_unlock(&ip_port_conn->mutex);
             }
-          }
-          if (spider_open_connections.array.max_element > old_elements) {
-            spider_alloc_calc_mem(
-                spider_current_trx, spider_open_connections,
-                (spider_open_connections.array.max_element - old_elements) *
-                    spider_open_connections.array.size_of_element);
           }
           /************************************************************************/
           /* Create conn_meta whose status is updated then when CONN object is
@@ -302,7 +478,7 @@ void spider_free_conn_from_trx(SPIDER_TRX *trx, SPIDER_CONN *conn, bool another,
           //	spider_my_err_logging("[ERROR] spider_add_conn_meta_info failed
           // for conn within conn_id=[%ull]!\n", conn->conn_id);
           //}
-          pthread_mutex_unlock(&spider_conn_mutex);
+          // pthread_mutex_unlock(&spider_conn_mutex);
         }
       }
     } else {
@@ -544,6 +720,7 @@ error_alloc_conn:
 SPIDER_CONN *spider_get_conn(SPIDER_SHARE *share, int link_idx, SPIDER_TRX *trx,
                              ha_spider *spider, bool another, bool thd_chg,
                              uint conn_kind, int *error_num) {
+  THD *thd = current_thd;
   SPIDER_CONN *conn = NULL;
   int base_link_idx = link_idx;
   ulong current_server_version = get_modify_server_version();
@@ -582,19 +759,13 @@ SPIDER_CONN *spider_get_conn(SPIDER_SHARE *share, int link_idx, SPIDER_TRX *trx,
   {
     if (!trx->thd || ((spider_param_conn_recycle_mode(trx->thd) & 1) ||
                       spider_param_conn_recycle_strict(trx->thd))) {
-      pthread_mutex_lock(&spider_conn_mutex);
-#ifdef SPIDER_HAS_HASH_VALUE_TYPE
-      if (!(conn = (SPIDER_CONN *)my_hash_search_using_hash_value(
-                &spider_open_connections, share->conn_keys_hash_value[link_idx],
+      // pthread_mutex_lock(&spider_conn_mutex);
+      if (!(conn = spd_connect_pools.get_conn(
+                share->conn_keys_hash_value[link_idx],
                 (uchar *)share->conn_keys[link_idx],
                 share->conn_keys_lengths[link_idx])))
-#else
-      if (!(conn = (SPIDER_CONN *)my_hash_search(
-                &spider_open_connections, (uchar *)share->conn_keys[link_idx],
-                share->conn_keys_lengths[link_idx])))
-#endif
       {
-        pthread_mutex_unlock(&spider_conn_mutex);
+        // pthread_mutex_unlock(&spider_conn_mutex);
         if (spider_param_max_connections()) { /* enable connection pool */
           conn = spider_get_conn_from_idle_connection(
               share, link_idx, share->conn_keys[link_idx], spider, conn_kind,
@@ -615,8 +786,8 @@ SPIDER_CONN *spider_get_conn(SPIDER_SHARE *share, int link_idx, SPIDER_TRX *trx,
           }
         }
       } else {
-        my_hash_delete(&spider_open_connections, (uchar *)conn);
-        pthread_mutex_unlock(&spider_conn_mutex);
+        // my_hash_delete(&spider_open_connections, (uchar *)conn);
+        // pthread_mutex_unlock(&spider_conn_mutex);
         DBUG_PRINT("info", ("spider get global conn"));
         if (spider) {
           spider->conns[base_link_idx] = conn;
@@ -3242,6 +3413,7 @@ SPIDER_CONN *spider_get_conn_from_idle_connection(
     SPIDER_SHARE *share, int link_idx, char *conn_key, ha_spider *spider,
     uint conn_kind, int base_link_idx, int *error_num) {
   DBUG_ENTER("spider_get_conn_from_idle_connection");
+  THD *thd = current_thd;
   SPIDER_IP_PORT_CONN *ip_port_conn;
   SPIDER_CONN *conn = NULL;
   uint spider_max_connections = spider_param_max_connections();
@@ -3299,22 +3471,16 @@ SPIDER_CONN *spider_get_conn_from_idle_connection(
         DBUG_RETURN(NULL);
       }
 
-      pthread_mutex_lock(&spider_conn_mutex);
-#ifdef SPIDER_HAS_HASH_VALUE_TYPE
-      if ((conn = (SPIDER_CONN *)my_hash_search_using_hash_value(
-               &spider_open_connections, share->conn_keys_hash_value[link_idx],
+      // pthread_mutex_lock(&spider_conn_mutex);
+      if ((conn = spd_connect_pools.get_conn(
+               share->conn_keys_hash_value[link_idx],
                (uchar *)share->conn_keys[link_idx],
                share->conn_keys_lengths[link_idx])))
-#else
-      if ((conn = (SPIDER_CONN *)my_hash_search(
-               &spider_open_connections, (uchar *)share->conn_keys[link_idx],
-               share->conn_keys_lengths[link_idx])))
-#endif
       {
         /* get conn from spider_open_connections, then delete conn in
          * spider_open_connections */
-        my_hash_delete(&spider_open_connections, (uchar *)conn);
-        pthread_mutex_unlock(&spider_conn_mutex);
+        // my_hash_delete(&spider_open_connections, (uchar *)conn);
+        // pthread_mutex_unlock(&spider_conn_mutex);
         DBUG_PRINT("info", ("spider get global conn"));
         if (spider) {
           spider->conns[base_link_idx] = conn;
@@ -3323,7 +3489,7 @@ SPIDER_CONN *spider_get_conn_from_idle_connection(
         }
         DBUG_RETURN(conn);
       } else {
-        pthread_mutex_unlock(&spider_conn_mutex);
+        // pthread_mutex_unlock(&spider_conn_mutex);
       }
     }
   } else { /* create conn */
@@ -3419,7 +3585,7 @@ void spider_free_ipport_conn(void *info) {
   DBUG_VOID_RETURN;
 }
 
-static void my_polling_last_visited(uchar *entry, void *data) {
+static my_bool my_polling_last_visited(uchar *entry, void *data) {
   DBUG_ENTER("my_polling_last_visited");
   SPIDER_CONN *conn = (SPIDER_CONN *)entry;
   delegate_param *param = (delegate_param *)data;
@@ -3434,9 +3600,9 @@ static void my_polling_last_visited(uchar *entry, void *data) {
                                   (char *)&conn->conn_key_hash_value,
                                   sizeof(conn->conn_key_hash_value));
 #else
-      HASH *spider_open_connections = param->hash_info;
-      my_hash_value_type hash_value = my_calc_hash(
-          spider_open_connections, conn->conn_key, conn->conn_key_length);
+      SPD_OPEN_CONN *soc = param->hash_info;
+      my_hash_value_type hash_value = soc->calc_hash(
+          conn->conn_key, conn->conn_key_length);
       append_dynamic_string_array(arr_info[0], (char *)&hash_value,
                                   sizeof(hash_value));
 #endif
@@ -3444,11 +3610,58 @@ static void my_polling_last_visited(uchar *entry, void *data) {
                                   conn->conn_key_length);
     }
 
-    DBUG_VOID_RETURN;
   }
+  return 0;
+}
+
+/*
+  new my_polling_last_visited() used by SPIDER_CONN_POOL::iterate()
+*/
+static my_bool poll_last_visited(uchar *entry, void *data) {
+  DBUG_ENTER("my_polling_last_visited");
+  conn_queue *cq = (conn_queue *)entry;
+  void *buffer = NULL;
+  bool buffer_malloced = false;
+  if (!cq || !cq->q_ptr) return FALSE; /* queue is empty */
+  assert(cq->mtx_inited);
+  pthread_mutex_lock(&cq->mtx);
+  /* this may be the bottleneck, since we do a mutex lock and walk
+     through the whole array, memcpy (used by get_dynamic) might also
+     account for the overhead
+  */
+  for (uint i = 0; i < cq->q_ptr->elements; i++) {
+    if (!buffer_malloced) {
+      buffer = my_malloc(sizeof(SPIDER_CONN **), MY_WME);
+      if (!buffer) return TRUE; /* OOM */
+      buffer_malloced = true;
+    }
+    get_dynamic(cq->q_ptr, buffer, i);
+    SPIDER_CONN *conn = *(SPIDER_CONN **)buffer;
+    delegate_param *param = (delegate_param *)data;
+    DYNAMIC_STRING_ARRAY **arr_info = param->arr_info;
+    if (conn) {
+      time_t time_now = time((time_t *)0);
+      if (time_now > 0 && time_now > conn->last_visited &&
+          time_now - conn->last_visited >=
+              spider_param_idle_conn_recycle_interval()) {
+        append_dynamic_string_array(arr_info[0],
+                                    (char *)&conn->conn_key_hash_value,
+                                    sizeof(conn->conn_key_hash_value));
+        append_dynamic_string_array(arr_info[1], (char *)conn->conn_key,
+                                    conn->conn_key_length);
+      }
+    } 
+  }
+  pthread_mutex_unlock(&cq->mtx);
+  if (buffer_malloced) {
+    my_free(buffer);
+    buffer = NULL;
+  }
+  return FALSE;
 }
 
 static void *spider_conn_recycle_action(void *arg) {
+  THD *thd = current_thd;
   DBUG_ENTER("spider_conn_recycle_action");
   DYNAMIC_STRING_ARRAY idle_conn_key_hash_value_arr;
   DYNAMIC_STRING_ARRAY idle_conn_key_arr;
@@ -3459,16 +3672,17 @@ static void *spider_conn_recycle_action(void *arg) {
   }
 
   delegate_param param;
-  param.hash_info = &spider_open_connections;
+  param.hash_info = &spd_connect_pools;
   param.arr_info[0] = &idle_conn_key_hash_value_arr;
   param.arr_info[1] = &idle_conn_key_arr;
   while (conn_rcyc_init) {
     clear_dynamic_string_array(&idle_conn_key_hash_value_arr);
     clear_dynamic_string_array(&idle_conn_key_arr);
 
-    pthread_mutex_lock(&spider_conn_mutex);
-    my_hash_delegate(&spider_open_connections, my_polling_last_visited, &param);
-    pthread_mutex_unlock(&spider_conn_mutex);
+    // pthread_mutex_lock(&spider_conn_mutex);
+    // my_hash_delegate(&spider_open_connections, my_polling_last_visited, &param);
+    // pthread_mutex_unlock(&spider_conn_mutex);
+    spd_connect_pools.iterate((my_hash_delegate_func)poll_last_visited, &param);
 
     for (size_t i = 0; i < idle_conn_key_hash_value_arr.cur_idx; ++i) {
       my_hash_value_type *tmp_ptr = NULL;
@@ -3488,20 +3702,10 @@ static void *spider_conn_recycle_action(void *arg) {
             "[ERROR] fill conn_key error from idle_conn_key_arr!\n");
         break;
       }
-      pthread_mutex_lock(&spider_conn_mutex);
-#ifdef SPIDER_HAS_HASH_VALUE_TYPE
-      SPIDER_CONN *conn = (SPIDER_CONN *)my_hash_search_using_hash_value(
-          &spider_open_connections, conn_key_hash_value, (uchar *)conn_key,
-          conn_key_len);
-
-#else
-      SPIDER_CONN *conn = (SPIDER_CONN *)my_hash_search(
-          &spider_open_connections, conn_key, conn_key_len);
-#endif
-      if (conn) {
-        my_hash_delete(&spider_open_connections, (uchar *)conn);
-      }
-      pthread_mutex_unlock(&spider_conn_mutex);
+      // pthread_mutex_lock(&spider_conn_mutex);
+      SPIDER_CONN *conn = spd_connect_pools.get_conn(conn_key_hash_value, 
+          (uchar *)conn_key, conn_key_len); 
+      // pthread_mutex_unlock(&spider_conn_mutex);
       if (conn) {
         spider_update_conn_meta_info(conn, SPIDER_CONN_INVALID_STATUS);
         spider_free_conn(conn);
@@ -4056,19 +4260,15 @@ SPIDER_FOR_STS_CONN *spider_create_sts_conn(char *key, ulong key_len,
 }
 
 void spider_free_conn_by_servername(char *servername) {
+  THD *thd = current_thd;
   SPIDER_CONN *conn = NULL;
   char conn_key[SPIDER_CONN_META_BUF_LEN + 2] = {0};
   uint conn_key_len = strlen(servername) + 1;
   conn_key[0] = '0';
   strmov(conn_key + 1, servername);
-  pthread_mutex_lock(&spider_conn_mutex);
 
-  while (conn = (SPIDER_CONN *)my_hash_search(
-             &spider_open_connections, (uchar *)conn_key, conn_key_len)) {
-    my_hash_delete(&spider_open_connections, (uchar *)conn);
-    pthread_mutex_unlock(&spider_conn_mutex);
+  while (conn = spd_connect_pools.get_conn_by_key((uchar *)conn_key,
+      conn_key_len)) {
     spider_free_conn(conn);
-    pthread_mutex_lock(&spider_conn_mutex);
   }
-  pthread_mutex_unlock(&spider_conn_mutex);
 }

--- a/storage/spider/spd_conn.cc
+++ b/storage/spider/spd_conn.cc
@@ -56,9 +56,9 @@ inline void SPIDER_set_next_thread_id(THD *A) {
 
 extern handlerton *spider_hton_ptr;
 extern SPIDER_DBTON spider_dbton[SPIDER_DBTON_SIZE];
-pthread_mutex_t spider_conn_id_mutex;
+// pthread_mutex_t spider_conn_id_mutex;
 pthread_mutex_t spider_ipport_conn_mutex;
-ulonglong spider_conn_id = 1;
+volatile longlong spider_conn_id = 0;
 
 extern pthread_attr_t spider_pt_attr;
 
@@ -649,10 +649,8 @@ SPIDER_CONN *spider_create_conn(SPIDER_SHARE *share, ha_spider *spider,
   spider_conn_queue_connect(share, conn, link_idx);
   conn->ping_time = (time_t)time((time_t *)0);
   conn->connect_error_time = conn->ping_time;
-  pthread_mutex_lock(&spider_conn_id_mutex);
+  my_atomic_add64(&spider_conn_id, 1LL);
   conn->conn_id = spider_conn_id;
-  ++spider_conn_id;
-  pthread_mutex_unlock(&spider_conn_id_mutex);
 
   pthread_mutex_lock(&spider_ipport_conn_mutex);
 #ifdef SPIDER_HAS_HASH_VALUE_TYPE

--- a/storage/spider/spd_conn.h
+++ b/storage/spider/spd_conn.h
@@ -36,9 +36,9 @@ public:
   my_hash_value_type calc_hash(const uchar *key, size_t length);
 
 private:
-  HASH connections; /* like std::*/
-  mysql_rwlock_t rw_lock;
-  bool conn_inited;
+  HASH connections;       /* like unordered_map<string, queue<conn*> > */
+  mysql_rwlock_t rw_lock; /* Read-Write Lock to secure the hash */
+  bool conn_inited;       /* whether the hash and rwlock hash inited */
 };
 
 uchar *spider_conn_get_key(SPIDER_CONN *conn, size_t *length,

--- a/storage/spider/spd_conn.h
+++ b/storage/spider/spd_conn.h
@@ -22,8 +22,30 @@
 #define SPIDER_BG_SIMPLE_DISCONNECT 2
 #define SPIDER_BG_SIMPLE_RECORDS 3
 
+class SPIDER_CONN_POOL {
+public:
+  SPIDER_CONN_POOL(){}
+
+  bool init(my_hash_get_key get_key, uint init_cap, CHARSET_INFO *charset);
+  void destroy();
+  bool put_conn(SPIDER_CONN *conn);
+  SPIDER_CONN *get_conn(my_hash_value_type v, uchar *conn, uint key_len);
+  SPIDER_CONN *get_conn_by_key(uchar *conn, uint key_len);
+  void iterate(my_hash_delegate_func iter_func, void *param);
+
+  my_hash_value_type calc_hash(const uchar *key, size_t length);
+
+private:
+  HASH connections; /* like std::*/
+  mysql_rwlock_t rw_lock;
+  bool conn_inited;
+};
+
 uchar *spider_conn_get_key(SPIDER_CONN *conn, size_t *length,
                            my_bool not_used __attribute__((unused)));
+
+uchar *spider_conn_pool_get_key(void *record, size_t *length,
+                                my_bool not_used __attribute__((unused)));
 
 uchar *spider_ipport_conn_get_key(SPIDER_IP_PORT_CONN *ip_port, size_t *length,
                                   my_bool not_used __attribute__((unused)));

--- a/storage/spider/spd_db_conn.cc
+++ b/storage/spider/spd_db_conn.cc
@@ -74,9 +74,6 @@ extern SPIDER_DBTON spider_dbton[SPIDER_DBTON_SIZE];
 #define SPIDER_SQL_PING_TABLE_STR "spider_ping_table("
 #define SPIDER_SQL_PING_TABLE_LEN (sizeof(SPIDER_SQL_PING_TABLE_STR) - 1)
 
-#ifdef SPIDER_HAS_HASH_VALUE_TYPE
-extern HASH spider_open_connections;
-#endif
 pthread_mutex_t spider_open_conn_mutex;
 const char spider_dig_upper[] = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
 

--- a/storage/spider/spd_db_mysql.cc
+++ b/storage/spider/spd_db_mysql.cc
@@ -52,7 +52,8 @@ extern bool volatile *spd_abort_loop;
 
 extern handlerton *spider_hton_ptr;
 extern pthread_mutex_t spider_open_conn_mutex;
-extern HASH spider_open_connections;
+extern SPIDER_CONN_POOL spd_connect_pools;
+// extern HASH spider_open_connections;
 extern HASH spider_ipport_conns;
 extern SPIDER_DBTON spider_dbton[SPIDER_DBTON_SIZE];
 extern const char spider_dig_upper[];
@@ -4924,8 +4925,8 @@ int spider_mysql_share::create_table_names_str() {
       if ((error_num = append_table_name(str, roop_count))) goto error;
     }
 #ifdef SPIDER_HAS_HASH_VALUE_TYPE
-    db_table_str_hash_value[roop_count] = my_calc_hash(
-        &spider_open_connections, (uchar *)str->ptr(), str->length());
+    db_table_str_hash_value[roop_count] = spd_connect_pools.calc_hash(
+      (uchar *)str->ptr(), str->length());
 #endif
   }
   DBUG_RETURN(0);

--- a/storage/spider/spd_direct_sql.cc
+++ b/storage/spider/spd_direct_sql.cc
@@ -483,7 +483,6 @@ error_alloc_conn:
 
 SPIDER_CONN *spider_udf_direct_sql_get_conn(const SPIDER_DIRECT_SQL *direct_sql,
                                             SPIDER_TRX *trx, int *error_num) {
-  THD *thd = current_thd;
   SPIDER_CONN *conn = NULL;
   DBUG_ENTER("spider_udf_direct_sql_get_conn");
 

--- a/storage/spider/spd_include.h
+++ b/storage/spider/spd_include.h
@@ -13,7 +13,7 @@
   along with this program; if not, write to the Free Software
   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
 
-#define SPIDER_DETAIL_VERSION "3.6.1"
+#define SPIDER_DETAIL_VERSION "3.7.1"
 #define SPIDER_HEX_VERSION 0x030500
 
 #if MYSQL_VERSION_ID < 50500

--- a/storage/spider/spd_table.cc
+++ b/storage/spider/spd_table.cc
@@ -306,7 +306,7 @@ ulong spider_init_error_tables_line_no;
 pthread_mutex_t spider_init_error_tbl_mutex;
 
 extern pthread_mutex_t spider_thread_id_mutex;
-extern pthread_mutex_t spider_conn_id_mutex;
+// extern pthread_mutex_t spider_conn_id_mutex;
 extern pthread_mutex_t spider_ipport_conn_mutex;
 
 #ifdef WITH_PARTITION_STORAGE_ENGINE
@@ -5056,7 +5056,7 @@ int spider_db_done(void *p) {
   pthread_mutex_destroy(&spider_pt_share_mutex);
 #endif
   pthread_mutex_destroy(&spider_init_error_tbl_mutex);
-  pthread_mutex_destroy(&spider_conn_id_mutex);
+  // pthread_mutex_destroy(&spider_conn_id_mutex);
   pthread_mutex_destroy(&spider_ipport_conn_mutex);
   pthread_mutex_destroy(&spider_thread_id_mutex);
   pthread_mutex_destroy(&spider_tbl_mutex);
@@ -5247,16 +5247,16 @@ int spider_db_init(void *p) {
     error_num = HA_ERR_OUT_OF_MEM;
     goto error_thread_id_mutex_init;
   }
-#if MYSQL_VERSION_ID < 50500
-  if (pthread_mutex_init(&spider_conn_id_mutex, MY_MUTEX_INIT_FAST))
-#else
-  if (mysql_mutex_init(spd_key_conn_id, &spider_conn_id_mutex,
-                       MY_MUTEX_INIT_FAST))
-#endif
-  {
-    error_num = HA_ERR_OUT_OF_MEM;
-    goto error_conn_id_mutex_init;
-  }
+// #if MYSQL_VERSION_ID < 50500
+//   if (pthread_mutex_init(&spider_conn_id_mutex, MY_MUTEX_INIT_FAST))
+// #else
+//   if (mysql_mutex_init(spd_key_conn_id, &spider_conn_id_mutex,
+//                        MY_MUTEX_INIT_FAST))
+// #endif
+//   {
+//     error_num = HA_ERR_OUT_OF_MEM;
+//     goto error_conn_id_mutex_init;
+//   }
 #if MYSQL_VERSION_ID < 50500
   if (pthread_mutex_init(&spider_ipport_conn_mutex, MY_MUTEX_INIT_FAST))
 #else
@@ -5663,7 +5663,7 @@ error_spd_xid_cache_mutex_init:
 #endif
   pthread_mutex_destroy(&spider_ipport_conn_mutex);
 error_ipport_count_mutex_init:
-  pthread_mutex_destroy(&spider_conn_id_mutex);
+  // pthread_mutex_destroy(&spider_conn_id_mutex);
 error_conn_id_mutex_init:
   pthread_mutex_destroy(&spider_thread_id_mutex);
 error_thread_id_mutex_init:

--- a/storage/spider/spd_table.cc
+++ b/storage/spider/spd_table.cc
@@ -122,7 +122,7 @@ extern SPIDER_DBTON spider_dbton_mysql;
 SPIDER_THREAD *spider_table_sts_threads;
 SPIDER_THREAD *spider_table_crd_threads;
 
-const int SPIDER_CONN_POOL_HASH_INIT_SIZE = 32;
+const int SPIDER_CONN_POOL_HASH_INIT_SIZE = 128;
 
 #ifdef HAVE_PSI_INTERFACE
 PSI_mutex_key spd_key_mutex_tbl;


### PR DESCRIPTION
[optimization] Use RWLock Hash with Mutex Stack in the connection pool

The original data structure is a hash using MUTEX to guarantee thread
safety. It uses `server_name#server_version` as key, connection instances
as value. Usually, a key corresponds to multiple values, so it's a
multi-map. Because the connection pool is similar to the
consumer-producer model, we redesigned the data structure, using a
unique hash map, where its key is `server_name#server_version`, value is
a stack of connection instances.
We use RWLock to secure the hash map since we don't usually change the
server version, the vast majority of operations are searching, rather than
insertion or deletion. Therefore, an RWLock will boost performance
significantly. We use a mutex to secure the stack. So we convert a
single mutex to multiple mutexes, which can also increase concurrency.

The structure is like
```cpp
std::unordered_map</* server_key */, std::stack<SPIDER_CONNECTIONS *> > conn_pool;
```

use atomic_add to replace mutex for spider_conn_id

[optimization] use rwlock in spider_conn_meta_mutex and spider_ipport_conn

[code-review] revision for spider connection pool